### PR TITLE
mintpy: typo & links fix + one more equation

### DIFF
--- a/UNAVCO2021/5.1_Intro_to_MintPy/smallbaselineApp_aria.ipynb
+++ b/UNAVCO2021/5.1_Intro_to_MintPy/smallbaselineApp_aria.ipynb
@@ -256,6 +256,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hidden": true,
     "hideCode": false,
     "hidePrompt": false
@@ -281,6 +282,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hidden": true,
     "hideCode": false,
     "hidePrompt": false
@@ -362,6 +364,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hidden": true,
     "hideCode": false,
     "hidePrompt": false
@@ -538,6 +541,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hidden": true,
     "hideCode": false,
     "hidePrompt": false
@@ -588,6 +592,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hidden": true,
     "hideCode": false,
     "hidePrompt": false
@@ -663,6 +668,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hidden": true,
     "hideCode": false,
     "hidePrompt": false
@@ -734,6 +740,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hidden": true,
     "hideCode": false,
     "hidePrompt": false
@@ -831,6 +838,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hidden": true,
     "hideCode": false,
     "hidePrompt": false
@@ -909,11 +917,11 @@
     "\n",
     "4) Further north and around latitude 38N another linear feature represents Concord fault parallel to Hayward fault.\n",
     "\n",
-    "5) Around latitude 37.9 N, a east-west linear discontinuity is evident. This is most likely caused by missing bursts in some interferograms. \n",
+    "5) Around latitude 37.9 N, a east-west linear discontinuity is evident. This is most likely caused by unwrapping errors due to imperfect phase stitching with frame-by-frame processing.\n",
     "\n",
-    "6) The red region at the south-east corenr (around 37.35 N, 121.9W) seems to be a hydrological signal showing ground uplift caused by acquifer recharge.\n",
+    "6) The green region at the south-east corenr (around 37.35 N, 121.9W; Santa Clara valley) seems to be a hydrological signal showing ground uplift caused by acquifer recharge (Schmidt and Bürgmann, 2003).\n",
     "\n",
-    "7) The block box at 37.7N, 122.3W is the reference pixel for this map. "
+    "7) The block box at [37.69N, 122.07W] is the reference pixel for this map. "
    ]
   },
   {
@@ -1010,6 +1018,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hideCode": false,
     "hidePrompt": false
    },
@@ -1030,6 +1039,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hideCode": false,
     "hidePrompt": false
    },
@@ -1062,13 +1072,25 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true"
+   },
+   "source": [
+    "### 3.1.2 Temporal coherence"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "heading_collapsed": "true",
     "hideCode": false,
     "hidePrompt": false
    },
    "source": [
-    "### 3.1.2 Temporal coherence\n",
+    "In addition to timeseries.h5 which contains the time-series dataset, \"invert_network\" produces other quantities, which contain metrics to evaluate the quality of the inversion including temporalCoherence.h5. Temporal coherence represents the consistency of the timeseries with the network of interferograms (Pepe and Lanari, 2006). \n",
     "\n",
-    "In addition to timeseries.h5 which contains the time-series dataset, \"invert_network\" produces other quantities, which contain metrics to evaluate the quality of the inversion including temporalCoherence.h5. Temporal coherence represents the consistency of the timeseries with the network of interferograms. \n",
+    "$$\\gamma_{temp}=\\frac{1}{M}|H^T\\exp[j(\\Delta\\phi-A\\hat{\\phi})]|$$\n",
+    "\n",
+    "where $\\Delta\\phi$ is the interferometric unwrapped phase, $A$ is the design matrix, $\\hat{\\phi}$ is the estimated time-series, $H$ is an $M\\times1$ all-ones column vector, $j$ is the imaginary unit.\n",
     "\n",
     "Temporal coherence varies from 0 to 1. Pixels with values closer to 1 are considered reliable and pixels with values closer to zero are considered unreliable. For a dense network of interferograms, a threshold of 0.7 may be used (Yunjun et al, 2019)."
    ]
@@ -1107,13 +1129,14 @@
    "source": [
     "<div class=\"alert alert-warning\">\n",
     "<b>Question:</b> \n",
-    "Generally, the temporal coherence may resamble the spatial pattern of the average spatial coherence. Under what condition, an area with very high average spatial coherence may show very low temporal coherence?  \n",
+    "Generally, the temporal coherence may resemble the spatial pattern of the average spatial coherence. Under what condition, an area with very high average spatial coherence may show very low temporal coherence?  \n",
     "</div>"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hideCode": false,
     "hidePrompt": false
    },
@@ -1197,6 +1220,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hideCode": false,
     "hidePrompt": false
    },
@@ -1316,6 +1340,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hideCode": false,
     "hidePrompt": false
    },
@@ -1389,7 +1414,7 @@
     "hidePrompt": false
    },
    "source": [
-    "Plotting the network after network modification shows how the network looks like"
+    "Plotting the interferogram after unwrapping error correction shows how well the correction is."
    ]
   },
   {
@@ -1414,6 +1439,15 @@
    "outputs": [],
    "source": [
     "view.main('inputs/ifgramStack.h5 unwrap*20160131_20170302 --zero-mask --figsize 12 6 --noverbose'.split())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "view.main('inputs/ifgramStack.h5 connectComponent-20160131_20170302 --noverbose'.split())"
    ]
   },
   {
@@ -1485,6 +1519,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hideCode": false,
     "hidePrompt": false
    },
@@ -1534,10 +1569,10 @@
     "\n",
     "<div class=\"alert alert-info\">\n",
     "<b>NOTE:</b> \n",
-    "If you choose to use variable network for different pixels, then interpret the temporal coherence with caution as the temporal coherence for a network with only obe connection between each acquisition and next acquisition is 1. A by product named numInvIfgram.h5 shows the number of interferograms used in the inversion for each pixel.\n",
+    "If you choose to use variable network for different pixels, then interpret the temporal coherence with caution as the temporal coherence for a network with only one connection between each acquisition and next acquisition is 1. A by product named numInvIfgram.h5 shows the number of interferograms used in the inversion for each pixel.\n",
     "</div>\n",
     "\n",
-    "MintPy by default masks the estimated time-series using waterMask.h5. However, the mask can be specified or can be turned off:\n",
+    "MintPy by default masks the estimated time-series using temporal coherence with a threshold:\n",
     "\n",
     "```cfg\n",
     "## Temporal coherence is calculated and used to generate the mask as the reliability measure\n",
@@ -1547,7 +1582,7 @@
     "mintpy.networkInversion.shadowMask  = auto #[yes / no], auto for yes [if shadowMask is in geometry file] or no.\n",
     "```\n",
     "\n",
-    "The least squares inversion can be performed using phase (A matrix in Berardino et al, 2002) or using phase velocity (B matrix in Berardino at al, 2002). The latter allows to invert a disconnected network. For a connected network, the design matrix is full-rank and the inversion using either methods are the same. The minimization is primarily based on L2 norm minimization. The L1 norm minimization has not been extensively tested. \n",
+    "The least squares inversion can be performed using phase (matrix A in Berardino et al, 2002) or using phase velocity (matrix B in Berardino at al, 2002). The latter allows to invert a disconnected network. For a connected network, the design matrix is full-rank and the inversion using either methods are the same. The minimization is primarily based on L2-norm minimization. The L1-norm minimization has not been extensively tested and disabled currrently. \n",
     "\n",
     "```cfg\n",
     "mintpy.networkInversion.minNormVelocity = auto #[yes / no], auto for yes, min-norm deformation velocity or phase\n",
@@ -1558,6 +1593,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hideCode": false,
     "hidePrompt": false
    },
@@ -1572,12 +1608,13 @@
     "hidePrompt": false
    },
    "source": [
-    "After inversion of the network of interferograms, the estimated time-series contains different components including tropospheric delay, topographic residuals ground displacement and other possible geophysical components (e.g., tide, ionosphere if they have not been corrected) or instrumental effects (e.g., the local oscilator drift of Envisat). Given ground displacement as our signal of interest, the following processing steps attempt to separate signal from noise and provide a ground displacement time-series for selected coherent pixels."
+    "After inversion of the network of interferograms, the estimated time-series contains different components including tropospheric delay, topographic residuals, ground displacement and other possible geophysical components (e.g., tide, ionosphere if they have not been corrected) or instrumental effects (e.g., the local oscilator drift of Envisat). Given ground displacement as our signal of interest, the following processing steps attempt to separate signal from noise and provide a ground displacement time-series for selected coherent pixels."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hideCode": false,
     "hidePrompt": false
    },
@@ -1598,6 +1635,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hideCode": false,
     "hidePrompt": false
    },
@@ -1612,7 +1650,7 @@
     "hidePrompt": false
    },
    "source": [
-    "This step corrects the solid Earth tides due to the gravity pull from the Sun and the Moon using [PySolid](https://github.com/insarlab/pysolid), which implements the IERS (International Earth Rotation and Reference Systems Service) 2010 convention (Petit & Luzum, 2010).\n",
+    "This step corrects the solid Earth tides due to the gravity pull from the Sun and the Moon using [PySolid](https://github.com/insarlab/pysolid), which implements the IERS (International Earth Rotation and Reference Systems Service) 2010 Conventions (Petit & Luzum, 2010).\n",
     "\n",
     "```cfg\n",
     "mintpy.solidEarthTides = auto #[yes / no], auto for no\n",
@@ -1622,6 +1660,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hideCode": false,
     "hidePrompt": false
    },
@@ -1711,6 +1750,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hideCode": false,
     "hidePrompt": false
    },
@@ -1743,6 +1783,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hideCode": false,
     "hidePrompt": false
    },
@@ -1830,6 +1871,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hideCode": false,
     "hidePrompt": false
    },
@@ -1906,6 +1948,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hideCode": false,
     "hidePrompt": false
    },
@@ -1951,6 +1994,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hideCode": false,
     "hidePrompt": false
    },
@@ -2008,17 +2052,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "hideCode": false,
-    "hidePrompt": false
-   },
-   "source": [
-    "Plots transect along a line specified with lat-lon coordinates. Check the link below for interactive plot:\n",
-    "https://nbviewer.jupyter.org/github/insarlab/MintPy/blob/main/docs/tutorials/plot_transection.ipynb"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -2039,7 +2072,17 @@
     "hidePrompt": false
    },
    "source": [
-    "The transect across Hayward fault shows ~2.5 mm/yr fault creep in LOS direction."
+    "The transect across Hayward fault shows ~3.5 mm/yr fault creep in LOS direction."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "hideCode": false,
+    "hidePrompt": false
+   },
+   "source": [
+    "Plots transect along a line specified with lat-lon coordinates. Check [plot_transection.ipynb](./visualization/plot_transection.ipynb) for interactive plot."
    ]
   },
   {
@@ -2086,7 +2129,7 @@
     "hidePrompt": false
    },
    "source": [
-    "In order to display the GPS station names on the plot add --gps-label to the plot."
+    "In order to display the GPS station names on the plot add `--gps-label` to the plot."
    ]
   },
   {
@@ -2104,6 +2147,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hidden": true,
     "hideCode": false,
     "hidePrompt": false
@@ -2130,6 +2174,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "heading_collapsed": "true",
     "hidden": true,
     "hideCode": false,
     "hidePrompt": false
@@ -2165,7 +2210,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "heading_collapsed": true,
+    "heading_collapsed": "true",
     "hidden": true,
     "hideCode": false,
     "hidePrompt": false
@@ -2200,7 +2245,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "heading_collapsed": true,
+    "heading_collapsed": "true",
     "hidden": true,
     "hideCode": false,
     "hidePrompt": false
@@ -2223,7 +2268,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "heading_collapsed": true,
+    "heading_collapsed": "true",
     "hidden": true,
     "hideCode": false,
     "hidePrompt": false
@@ -2248,7 +2293,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "heading_collapsed": true,
+    "heading_collapsed": "true",
     "hidden": true,
     "hideCode": false,
     "hidePrompt": false
@@ -2273,7 +2318,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "heading_collapsed": true,
+    "heading_collapsed": "true",
     "hidden": true,
     "hideCode": false,
     "hidePrompt": false
@@ -2310,7 +2355,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "heading_collapsed": true,
+    "heading_collapsed": "true",
     "hidden": true,
     "hideCode": false,
     "hidePrompt": false
@@ -2336,7 +2381,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "heading_collapsed": true,
+    "heading_collapsed": "true",
     "hidden": true,
     "hideCode": false,
     "hidePrompt": false


### PR DESCRIPTION
This PR fixes a few typo and links in the mintpy notebook, plus add one more equation on the temporal coherence. The default `unavco` kernel is kept and untouched. All good stuff.