### PR TITLE
update README for UNAVCO2022

### DIFF
--- a/UNAVCO2022/0.0_Pre-Course_and_Course_Roadmap/README.md
+++ b/UNAVCO2022/0.0_Pre-Course_and_Course_Roadmap/README.md
@@ -5,9 +5,9 @@ Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Fr
 
 TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0
 
 Pre-course self-directed: 
 

--- a/UNAVCO2022/0.0_Pre-Course_and_Course_Roadmap/README.md
+++ b/UNAVCO2022/0.0_Pre-Course_and_Course_Roadmap/README.md
@@ -1,9 +1,9 @@
 # Pre-Course and Course Roadmap
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
 ISCE Version: v2.5.2
 

--- a/UNAVCO2022/0.1_Math_Basics/README.md
+++ b/UNAVCO2022/0.1_Math_Basics/README.md
@@ -1,13 +1,13 @@
 # Math Basics
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0
 
 Resource: MathBasics.ipynb
 

--- a/UNAVCO2022/0.2_Python-unix-plotting-numpy/README.md
+++ b/UNAVCO2022/0.2_Python-unix-plotting-numpy/README.md
@@ -1,13 +1,13 @@
 # Python-unix-plotting-numpy
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0
 
 Resource: https://byu-hydroinformatics.edunext.io/courses
 

--- a/UNAVCO2022/0.3 Accessing and Working within the OpenSARLab (OSL)/README.md
+++ b/UNAVCO2022/0.3 Accessing and Working within the OpenSARLab (OSL)/README.md
@@ -1,13 +1,13 @@
 # Accessing and Working within the OpenSARLab
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0
 
 Resource: OSL Video linked on syllabus
 

--- a/UNAVCO2022/0.4_Geographic_Information_Science_using_GDAL/README.md
+++ b/UNAVCO2022/0.4_Geographic_Information_Science_using_GDAL/README.md
@@ -1,13 +1,13 @@
 # Geographic Information Science using GDAL
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0
 
 Resource: 01_IntroTo_RasterData.ipynb, 02_RasterDataManipulation.ipynb, 03_RasterProjection.ipynb
 

--- a/UNAVCO2022/0.5_Raster_Data_Tiling+Map_Projections/README.md
+++ b/UNAVCO2022/0.5_Raster_Data_Tiling+Map_Projections/README.md
@@ -1,13 +1,13 @@
 # Raster Data Tiling + Map Projections
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0
 
 Resource: Raster Data Manipulation Video and Map Projection Video linked on syllabus
 

--- a/UNAVCO2022/0.6_Installation_of_ISCE_using_conda_and_containers/README.md
+++ b/UNAVCO2022/0.6_Installation_of_ISCE_using_conda_and_containers/README.md
@@ -1,13 +1,13 @@
 # Installation of ISCE using conda and containers
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0
 
 Resource: https://github.com/isce-framework/isce2
 

--- a/UNAVCO2022/0.7_Data_Search_and_Access/README.md
+++ b/UNAVCO2022/0.7_Data_Search_and_Access/README.md
@@ -1,13 +1,13 @@
 # Data Search and Access
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0
 
 Resource: SSARA.ipynb, GRFN.ipynb
 

--- a/UNAVCO2022/0.8_SAR_Theory_Phenomenology/README.md
+++ b/UNAVCO2022/0.8_SAR_Theory_Phenomenology/README.md
@@ -1,13 +1,13 @@
 # SAR Theory Phenomenology
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0
 
 Resource: SAR.ipynb 
 

--- a/UNAVCO2022/0.9_SAR_Imaging_Theory/README.md
+++ b/UNAVCO2022/0.9_SAR_Imaging_Theory/README.md
@@ -1,13 +1,13 @@
 # SAR Imaging Theory
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0
 
 Resource: SAR_Processor.ipynb
 

--- a/UNAVCO2022/1.0_Introductions+Agenda_Review/README.md
+++ b/UNAVCO2022/1.0_Introductions+Agenda_Review/README.md
@@ -1,5 +1,5 @@
 # Introductions + Agenda Review 
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
 Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 

--- a/UNAVCO2022/1.0_Introductions+Agenda_Review/README.md
+++ b/UNAVCO2022/1.0_Introductions+Agenda_Review/README.md
@@ -1,11 +1,10 @@
 # Introductions + Agenda Review 
 2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
-
+MintPy Version: v1.4.0

--- a/UNAVCO2022/1.1_Recap_of_OSL-downloading_training/README.md
+++ b/UNAVCO2022/1.1_Recap_of_OSL-downloading_training/README.md
@@ -1,13 +1,13 @@
 # Recap of OSL downloading training
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0
 
 Resource: OSL Video linked on syllabus
 

--- a/UNAVCO2022/1.2_Geophysical_Modeling_with_InSAR-GNSS-Geodetic_Data/README.md
+++ b/UNAVCO2022/1.2_Geophysical_Modeling_with_InSAR-GNSS-Geodetic_Data/README.md
@@ -1,13 +1,13 @@
 # Geophysical Modeling with InSAR-GNSS-Geodetic Data
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0
 
 Resource: intro_to_geophysical_modeling.pdf, intro_to_geophysical_modeling.pptx
 

--- a/UNAVCO2022/1.3_InSAR_theory/README.md
+++ b/UNAVCO2022/1.3_InSAR_theory/README.md
@@ -1,13 +1,13 @@
 # InSAR Theory
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0
 
 Resource: InSAR.ipynb, Correlation.ipynb, Interpreting InSAR data.ipynb
 

--- a/UNAVCO2022/1.4_Stripmap_Data_Processing_Interferometry/README.md
+++ b/UNAVCO2022/1.4_Stripmap_Data_Processing_Interferometry/README.md
@@ -1,13 +1,13 @@
 # Stripmap Data Processing Interferometry
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0
 
 Resource: stripmapApp.ipynb
 

--- a/UNAVCO2022/2.0_Review_Day_1_homework_results_and_problems_encountered/README.md
+++ b/UNAVCO2022/2.0_Review_Day_1_homework_results_and_problems_encountered/README.md
@@ -1,11 +1,10 @@
 # Review Day 1 homework 
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
-
+MintPy Version: v1.4.0

--- a/UNAVCO2022/2.1_Interpreting_a_co-seismic_interferogram/README.md
+++ b/UNAVCO2022/2.1_Interpreting_a_co-seismic_interferogram/README.md
@@ -1,14 +1,14 @@
-# interpretingInSAR
+# Interpreting InSAR
 
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0
 
 Resource: Interpreting InSAR data.ipynb
 

--- a/UNAVCO2022/2.2_TOPS_Data_Processing/README.md
+++ b/UNAVCO2022/2.2_TOPS_Data_Processing/README.md
@@ -1,13 +1,13 @@
 # TOPS Data Processing
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0
 
 Resource: topsApp.ipynb, dloadOrbits.py 
 

--- a/UNAVCO2022/3.0_Review_Day_2_homework_results_and_problems_encountered/README.md
+++ b/UNAVCO2022/3.0_Review_Day_2_homework_results_and_problems_encountered/README.md
@@ -1,10 +1,10 @@
 # Review Day 2 homework
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0

--- a/UNAVCO2022/3.1_Preparing_InSAR_data_for_modeling/README.md
+++ b/UNAVCO2022/3.1_Preparing_InSAR_data_for_modeling/README.md
@@ -1,14 +1,14 @@
 # Preparing InSAR data for modeling
 
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0
 
 InSAR processing is only the starting point for a geophysical analysis of surface deformation. In order to use our unwrapped interferograms to constrain geophysical models, we need to consider a couple of things: the number of datapoints and the satellite line-of-sight vector. 
 

--- a/UNAVCO2022/3.2_Time-series_theory/README.md
+++ b/UNAVCO2022/3.2_Time-series_theory/README.md
@@ -1,13 +1,13 @@
 # Time-series Theory
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0
 
 Resource: ARIA video linked in syllabus
 

--- a/UNAVCO2022/3.3_Interferogram_stacks_with_ARIA_tools/README.md
+++ b/UNAVCO2022/3.3_Interferogram_stacks_with_ARIA_tools/README.md
@@ -1,13 +1,13 @@
 # Interferogram Stacks: Temporal-spatial statistical considerations
  2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, Eric Fielding, Heresh Fattahi, Gareth Funning, Franz Meyer, Simran Sangha, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Becca Bussard, Niloufar Abolfathian, Brett Buzzanga, Emre Havazli
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0
 
 Resource: ARIATSSetup, ARIA video linked in syllabus
 

--- a/UNAVCO2022/4.0_Review_Day_3_homework_results_and_problems_encountered/README.md
+++ b/UNAVCO2022/4.0_Review_Day_3_homework_results_and_problems_encountered/README.md
@@ -1,10 +1,10 @@
 # Review Day 3 Homework
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0

--- a/UNAVCO2022/4.1_SAR_imaging_missions_and_their_capabilities/README.md
+++ b/UNAVCO2022/4.1_SAR_imaging_missions_and_their_capabilities/README.md
@@ -1,4 +1,4 @@
-# SAR Imaging Missions and Their Capabilities
+# SAR Imaging Missions
 
 2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 

--- a/UNAVCO2022/4.1_SAR_imaging_missions_and_their_capabilities/README.md
+++ b/UNAVCO2022/4.1_SAR_imaging_missions_and_their_capabilities/README.md
@@ -1,0 +1,11 @@
+# SAR Imaging Missions and Their Capabilities
+
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
+
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
+
+ISCE Version: v2.6
+
+MintPy Version: v1.4.0

--- a/UNAVCO2022/4.2_Tropo_Ionosphere+Split_Spectrum/README.md
+++ b/UNAVCO2022/4.2_Tropo_Ionosphere+Split_Spectrum/README.md
@@ -1,13 +1,13 @@
 # Tropo + Ionosphere + Split Spectrum
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0
 
 Resource: stripmapApp_ionosphere.ipynb, Tropo.ipynb
 

--- a/UNAVCO2022/4.3_Offset_stack_for_velocity_dynamics_with_autoRIFT/README.md
+++ b/UNAVCO2022/4.3_Offset_stack_for_velocity_dynamics_with_autoRIFT/README.md
@@ -1,13 +1,16 @@
 # Offset stack for velocity dynamics
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+# Tropo + Ionosphere + Split Spectrum
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-ISCE Version: v2.5.2
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-MintPy Version: v1.3.1
+ISCE Version: v2.6
+
+MintPy Version: v1.4.0
 
 Resource: Module resources
 

--- a/UNAVCO2022/4.3_Offset_stack_for_velocity_dynamics_with_autoRIFT/README.md
+++ b/UNAVCO2022/4.3_Offset_stack_for_velocity_dynamics_with_autoRIFT/README.md
@@ -1,9 +1,6 @@
 # Offset stack for velocity dynamics
 2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-# Tropo + Ionosphere + Split Spectrum
-2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
-
 Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
 TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali

--- a/UNAVCO2022/4.4_Decomposition_of_velocities_from_multiple_viewing_geometries/README.md
+++ b/UNAVCO2022/4.4_Decomposition_of_velocities_from_multiple_viewing_geometries/README.md
@@ -1,0 +1,10 @@
+# Decomposition of Velocities
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
+
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
+
+ISCE Version: v2.6
+
+MintPy Version: v1.4.0

--- a/UNAVCO2022/5.0_Review_Day_4_homework_results_and_problems_encountered/README.md
+++ b/UNAVCO2022/5.0_Review_Day_4_homework_results_and_problems_encountered/README.md
@@ -1,11 +1,10 @@
 # Review Day 4 Homework Results
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
-
+MintPy Version: v1.4.0

--- a/UNAVCO2022/5.1_NISAR/README.md
+++ b/UNAVCO2022/5.1_NISAR/README.md
@@ -1,13 +1,16 @@
 # Intro to MintPy
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+# Tropo + Ionosphere + Split Spectrum
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-ISCE Version: v2.5.2
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-MintPy Version: v1.3.1
+ISCE Version: v2.6
+
+MintPy Version: v1.4.0
 
 Resource: smallbaselineApp_aria.ipynb
 

--- a/UNAVCO2022/5.1_NISAR/README.md
+++ b/UNAVCO2022/5.1_NISAR/README.md
@@ -1,7 +1,4 @@
-# Intro to MintPy
-2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
-
-# Tropo + Ionosphere + Split Spectrum
+# NISAR
 2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
 Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
@@ -11,9 +8,3 @@ TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 ISCE Version: v2.6
 
 MintPy Version: v1.4.0
-
-Resource: smallbaselineApp_aria.ipynb
-
-Expected Outcome: Develop an understanding of the capabilities of MintPy, expected inputs and possible outputs, and control parameters
-
-Assessment: Final project that brings together everything in previous lectures, including a time series analysis using MintPy, followed by an inversion of a specific model for one or two interferograms in the stack.  Could pick something like a dyke intrusion event, and analyze nearest pair and other pairs spanning the event and see how the models differ.

--- a/UNAVCO2022/5.2_Intro_to_MintPy/README.md
+++ b/UNAVCO2022/5.2_Intro_to_MintPy/README.md
@@ -1,13 +1,13 @@
 # Intro to MintPy
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0
 
 Resource: smallbaselineApp_aria.ipynb
 

--- a/UNAVCO2022/5.3_Time_Series_Analysis_with_MintPy/README.md
+++ b/UNAVCO2022/5.3_Time_Series_Analysis_with_MintPy/README.md
@@ -1,15 +1,15 @@
 # Time Series Analysis with MintPy
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0
 
-Resource: smallbaselineApp_aria.ipynb in section 5.1
+Resource: smallbaselineApp_aria.ipynb in section 5.2
 
 Expected Outcome: Develop an intuition in running and examining the results from MintPy
 

--- a/UNAVCO2022/5.4_Intro_to_preparing_data_for_stack_processing/README.md
+++ b/UNAVCO2022/5.4_Intro_to_preparing_data_for_stack_processing/README.md
@@ -1,13 +1,13 @@
 # Intro to Preparing Data for Stack Processing
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
+MintPy Version: v1.4.0
 
 Resource: stackStripMap and topsStack videos linked on syllabus
 

--- a/UNAVCO2022/README.md
+++ b/UNAVCO2022/README.md
@@ -16,15 +16,15 @@ This repository is meant for Jupyter notebooks meant for instruction at UNAVCO S
 Instructors
 -----------
 
-1. Paul Rosen (JPL)
-2. David Bekaert (JPL)
-3. Heresh Fattahi (JPL)
-4. Gareth Funning (UC Riverside)
+1. Heresh Fattahi (Jet Propulsion Laboratory)
+2. Eric Fielding (Jet Propulsion Laboratory)
+3. Gareth Funning (University of California, Riverside)
+4. Alex Lewandowski (University of Alaska, Fairbanks)
 5. Franz Meyer (University of Alaska, Fairbanks)
-6. Brent Minchew (Massachusetts Institute of Technology)
-7. Zhang Yunjun (California Institute of Technology)
-8. Hilarie Davis (Technology for Learning Consortium)
-
+6. Paul Rosen (Jet Propulsion Laboratory)
+7. Simran Sangha (Jet Propulsion Laboratory)
+8. Forrest Williams (University of Alaska, Fairbanks)
+9. Zhang Yunjun (California Institute of Technology)
 
 Jupyter setup
 -------------

--- a/UNAVCO2022/Removed_Time_Series_Analysis_with_MintPy_Error_analysis_and_noise_reduction/README.md
+++ b/UNAVCO2022/Removed_Time_Series_Analysis_with_MintPy_Error_analysis_and_noise_reduction/README.md
@@ -1,12 +1,10 @@
 # Time Series Analysis with MintPy Error Analysis
-2021 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
+2022 InSAR Processing and Time-Series Analysis for Geophysical Applications: ISCE, ARIA-Tools, and MintPy
 
-Instructors: Paul Rosen, David Bekaert, Heresh Fattahi, Gareth Funning, Franz Meyer, Brent Minchew, Hilarie Davis, Zhang Yunjun
+Instructors: Heresh Fattahi, Eric Fielding, Gareth Funning, Alex Lewandowski, Franz Meyer, Paul Rosen, Simran Sangha, Forrest William, Zhang Yunjun
 
-TA’s: Shubham Awasthi, Faizan Sabir, Luyen Bui, Pratyusha Gonnuru, Becca Bussard
+TA’s: Niloufar Abolfathian, Becca Bussard, Brett Buzzanga, Emre Havazali
 
-ISCE Version: v2.5.2
+ISCE Version: v2.6
 
-MintPy Version: v1.3.1
-
-Resource: smallbaselineApp_aria.ipynb in section 5.1
+MintPy Version: v1.4.0


### PR DESCRIPTION
README files in all directories updated.
list of changes:
- year '2021' --> year '2022'
- instructors and TA names updated
- ISCE and MintPy versions updated to ISCE v2.6 and MintPy v1.4.0
- few other details added as needed to some of the README files