### PR TITLE
replaced corrupted 2021 SAR Processor module with the 2022 version

### DIFF
--- a/UNAVCO2021/0.9_SAR_Imaging_Theory/SAR_Processor.ipynb
+++ b/UNAVCO2021/0.9_SAR_Imaging_Theory/SAR_Processor.ipynb
@@ -3391,11 +3391,7 @@
   "celltoolbar": "Slideshow",
   "hide_code_all_hidden": false,
   "kernelspec": {
-<<<<<<< Updated upstream
    "display_name": "Python 3 (ipykernel)",
-=======
-   "display_name": "Python 3",
->>>>>>> Stashed changes
    "language": "python",
    "name": "python3"
   },
@@ -3409,11 +3405,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-<<<<<<< Updated upstream
    "version": "3.9.12"
-=======
-   "version": "3.9.7"
->>>>>>> Stashed changes
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I believe I fixed the corrupted 2021 SAR Processor notebook.  It shows up properly in github interface.  Someone please check!