### PR TITLE
Update 01_IntroToRasterData.ipynb

### DIFF
--- a/EarthScope2023/0.4_Geographic_Information_Science_using_GDAL/01_IntroToRasterData.ipynb
+++ b/EarthScope2023/0.4_Geographic_Information_Science_using_GDAL/01_IntroToRasterData.ipynb
@@ -72,7 +72,7 @@
     "<b>NEW ISSUE:</b> \n",
     "Starting in January 2022, the OpenTopography servers require an OpenTopography API key for all download requests.\n",
     "\n",
-    "See https://portal.opentopography.org/lidarAuthorizationInfo for more information on getting API key. When you have the API key, replace the `nnn` in the next command with your key.\n",
+    "See https://portal.opentopography.org/ for more information on getting API key. When you have the API key, replace the `nnn` in the next command with your key.\n",
     "</div>\n",
     "\n",
     "There is also more information about this OpenTopography API key in the `UNAVCO2022/0.7_Data_Search_and_Access/Data_Access_Accounts.ipynb` notebook."


### PR DESCRIPTION
The old link: https://portal.opentopography.org/lidarAuthorizationInfo just led to a page that said "no". Removing the lidarAuthorizationInfo from the url got me to a log in page I could use to get an API.